### PR TITLE
feat: added parameters for left and right delims

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ To build the binary yourself, you need to have Go installed. Then, clone the rep
 | `-o` | `--output` | string | The path to the output file. (default "output.txt") |
 | `-s` | `--source` | string | The path to the source file containing template data. Valid values are: <file>.<json|yaml>. If format is env, this flag caries the  |prefix for the environment variables. (default "TMPLX_")
 | `-t` | `--template` | string | The path to the template file. (default "template.tmpl") |
+| `-l` | `delim-left` | string | `{{` | The left delimiter for the template engine. |
+| `-r` | `delim-right` | string | `}}` | The right delimiter for the template engine. |
 | `-v` | `--version` | | version for tmpls |
 
 ### Example
@@ -56,4 +58,10 @@ export TMPLX_USER_ACCOUNT_10="user10:pass10"
 
 ```bash
 tmplx -t _tests/template.tmpl --dry-run
+```
+
+With custom delim:
+
+```bash
+go run main.go -t _tests/custom_delim.tmpl --dry-run -l '{|' -r '|}'
 ```

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ To build the binary yourself, you need to have Go installed. Then, clone the rep
 | `-o` | `--output` | string | The path to the output file. (default "output.txt") |
 | `-s` | `--source` | string | The path to the source file containing template data. Valid values are: <file>.<json|yaml>. If format is env, this flag caries the  |prefix for the environment variables. (default "TMPLX_")
 | `-t` | `--template` | string | The path to the template file. (default "template.tmpl") |
-| `-l` | `delim-left` | string | `{{` | The left delimiter for the template engine. |
-| `-r` | `delim-right` | string | `}}` | The right delimiter for the template engine. |
+| `-l` | `--delim-left` | string | `{{` | The left delimiter for the template engine. |
+| `-r` | `--delim-right` | string | `}}` | The right delimiter for the template engine. |
 | `-v` | `--version` | | version for tmpls |
 
 ### Example

--- a/_tests/custom_delim.tmpl
+++ b/_tests/custom_delim.tmpl
@@ -1,0 +1,28 @@
+Hello World!
+
+------
+
+{|- range $key, $value := .Values |}
+    {| $key |} = {| $value |}
+    Username and Password: {| hasPrefix "TMPLX_USER_ACCOUNT_" $key |}
+
+{|- end |}
+
+------
+
+{|- $myMap := filterMap .Values "TMPLX_USER_ACCOUNT_" |}
+{|- if gt (mapLength $myMap) 0 |}
+[
+{|- end |}
+{|- range $key, $value := $myMap |}
+    {|- $usrPw := splitN $value ":" 2 |}
+    {|- $usr := index $usrPw 0 |}
+    {|- $pw := index $usrPw 1 |}
+    (
+        username = {| $usr |}
+        password = {| $pw |}
+    )
+{|- end |}
+{|- if gt (mapLength $myMap) 0 |}
+]
+{|- end |}

--- a/main.go
+++ b/main.go
@@ -31,7 +31,13 @@ var (
 				return err
 			}
 
-			tmplBts, err := template.Render(tmplTemplate, tmplData)
+			options := []template.TemplateOption{}
+			// check if delimiters are set
+			if *flagValueDelimLeft != "" && *flagValueDelimRight != "" {
+				options = append(options, template.WithDelims(*flagValueDelimLeft, *flagValueDelimRight))
+			}
+
+			tmplBts, err := template.Render(tmplTemplate, tmplData, options...)
 			if err != nil {
 				return err
 			}
@@ -63,6 +69,8 @@ var (
 	flagValueFormat       *string
 	flagValueSource       *string
 	flagValueDryRun       *bool
+	flagValueDelimLeft    *string
+	flagValueDelimRight   *string
 )
 
 // we use the init function to setup the version information and flags for the root command
@@ -94,6 +102,8 @@ func init() {
 	flagValueFormat = rootCmd.Flags().StringP("format", "f", "env", "The format of the template data. Valid values are: env, json, yaml.")
 	flagValueSource = rootCmd.Flags().StringP("source", "s", "TMPLX_", "The path to the source file containing template data. Valid values are: <file>.<json|yaml>. If format is env, this flag caries the prefix for the environment variables.")
 	flagValueDryRun = rootCmd.Flags().BoolP("dry-run", "d", false, "If set, the output will not be written to the output file.")
+	flagValueDelimLeft = rootCmd.Flags().StringP("delim-left", "l", "{{", "The left delimiter for the template.")
+	flagValueDelimRight = rootCmd.Flags().StringP("delim-right", "r", "}}", "The right delimiter for the template.")
 }
 
 func main() {

--- a/template/template.go
+++ b/template/template.go
@@ -35,18 +35,23 @@ func DataSource(src string) (DataSourceFunc, error) {
 	}
 }
 
-func newTemplate(templateData []byte) (*template.Template, error) {
-	return template.New("my").Funcs(sprig.FuncMap()).Funcs(GenericFuncMap()).Parse(string(templateData))
+func newTemplate(templateData []byte, options ...TemplateOption) (*template.Template, error) {
+	t := template.New("my").Funcs(sprig.FuncMap()).Funcs(GenericFuncMap())
+	// apply options
+	for _, opt := range options {
+		opt(t)
+	}
+	return t.Parse(string(templateData))
 }
 
 // Render renders the template data to the given writer.
-func Render(templateData []byte, data map[string]any) ([]byte, error) {
+func Render(templateData []byte, data map[string]any, options ...TemplateOption) ([]byte, error) {
 	// create template
-	t, err := newTemplate(templateData)
+	t, err := newTemplate(templateData, options...)
 	if err != nil {
 		return nil, err
 	}
-	// parse template
+	// execute template
 	bbuf := bytes.NewBuffer([]byte{})
 	err = t.Execute(bbuf, Data{Values: data})
 	if err != nil {

--- a/template/template_options.go
+++ b/template/template_options.go
@@ -1,0 +1,15 @@
+package template
+
+import (
+	"text/template"
+)
+
+type TemplateOption func(*template.Template)
+
+// WithDelims returns a template option that sets the left and right delimiters.
+func WithDelims(left, right string) TemplateOption {
+	return func(t *template.Template) {
+		// overwrite delimiters
+		t.Delims(left, right)
+	}
+}

--- a/template/template_options_test.go
+++ b/template/template_options_test.go
@@ -1,0 +1,36 @@
+package template
+
+import (
+	"testing"
+	"text/template"
+)
+
+func TestWithDelims(t *testing.T) {
+	type args struct {
+		left  string
+		right string
+	}
+	tests := []struct {
+		name string
+		args args
+		want TemplateOption
+	}{
+		{
+			name: "basic check if delimiters can be set",
+			args: args{
+				left:  "{{",
+				right: "}}",
+			},
+			want: func(t *template.Template) {
+				t.Delims("{{", "}}")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t1 := template.New("test")
+			WithDelims(tt.args.left, tt.args.right)(t1)
+			// TODO: check if delimeters are set
+		})
+	}
+}


### PR DESCRIPTION
# Description

Added parameters for the adjustment of left and right template delimiters.

## How Has This Been Tested?

- [x] `go run main.go -t _tests/template.tmpl --dry-run`
- [x] `go run main.go -t _tests/custom_delim.tmpl --dry-run -l '{|' -r '|}'`

**Test Configuration**:

- Go version: `v1.21.x`
- OS: `linux`
- Architecture: `amd64`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
